### PR TITLE
feat: Option to not hash the salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ module.exports = {
     contract: "YOUR_CONTRACT_NAME_TO_BE_DEPLOYED",
     constructorArgsPath: "PATH_TO_CONSTRUCTOR_ARGS",
     salt: "YOUR_SALT_MESSAGE",
+    // The default option is to hash the salt, even if this is undefined.
+    // Should the salt not be hashed, make this "false".
+    hashSalt: "true",
     signer: "SIGNER_PRIVATE_KEY",
     networks: ["LIST_OF_NETWORKS"],
     rpcUrls: ["LIST_OF_RPCURLS"],
@@ -85,6 +88,9 @@ const config: HardhatUserConfig = {
     contract: "YOUR_CONTRACT_NAME_TO_BE_DEPLOYED",
     constructorArgsPath: "PATH_TO_CONSTRUCTOR_ARGS",
     salt: "YOUR_SALT_MESSAGE",
+    // The default option is to hash the salt, even if this is undefined.
+    // Should the salt not be hashed, make this "false".
+    hashSalt: "true",
     signer: "SIGNER_PRIVATE_KEY",
     networks: ["LIST_OF_NETWORKS"],
     rpcUrls: ["LIST_OF_RPCURLS"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,11 +109,16 @@ task(
           signers[i]
         );
 
-        if (hre.config.xdeploy.salt) {
+        let salt = hre.config.xdeploy.salt;
+        if (salt) {
+          if (hre.config.xdeploy.hashSalt !== "false") {
+            salt = hre.ethers.utils.id(salt);
+          }
+
           try {
             let counter = 0;
             computedContractAddress = await create2Deployer[i].computeAddress(
-              hre.ethers.utils.id(hre.config.xdeploy.salt),
+              salt,
               hre.ethers.utils.keccak256(initcode.data)
             );
             if (counter === 0) {
@@ -143,7 +148,7 @@ task(
           try {
             createReceipt[i] = await create2Deployer[i].deploy(
               AMOUNT,
-              hre.ethers.utils.id(hre.config.xdeploy.salt),
+              salt,
               initcode.data,
               { gasLimit: hre.config.xdeploy.gasLimit }
             );

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface XdeployConfig {
   contract?: string;
   constructorArgsPath?: string;
   salt?: string;
+  hashSalt?: "true" | "false";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   signer?: any;
   networks?: Array<string>;


### PR DESCRIPTION
<!--
Thank you for using xdeployer and taking the time to send a pull request (PR)!

If you are introducing a new feature, please discuss it in an issue or in the discussions section before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

#### PR Checklist

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [x] Because this PR includes a **new feature**, the change was previously discussed in an [issue](https://github.com/pcaversaccio/xdeployer/issues) or in the [discussions](https://github.com/pcaversaccio/xdeployer/discussions) section.
- [ ] I didn't do anything of this.

---

<!-- Add a description of your PR here -->
Provide an option to use the salt provided as is instead of hashing the salt because xdeployer doesn't work in the case where the salt is found by a program to find gas-efficient contract addresses.