### PR TITLE
♻️ Include Contract Name in Deployment File Name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ task(
               path.join(
                 hre.config.paths.root,
                 "deployments",
-                `${hre.config.xdeploy.networks[i]}_deployment.json`,
+                `${hre.config.xdeploy.contract}_${hre.config.xdeploy.networks[i]}_deployment.json`,
               ),
             );
 
@@ -216,7 +216,7 @@ task(
               path.join(
                 hre.config.paths.root,
                 "deployments",
-                `${hre.config.xdeploy.networks[i]}_deployment_debug.json`,
+                `${hre.config.xdeploy.contract}_${hre.config.xdeploy.networks[i]}_deployment_debug.json`,
               ),
             );
 
@@ -309,7 +309,7 @@ task(
               path.join(
                 hre.config.paths.root,
                 "deployments",
-                `${hre.config.xdeploy.networks[i]}_deployment.json`,
+                `${hre.config.xdeploy.contract}_${hre.config.xdeploy.networks[i]}_deployment.json`,
               ),
             );
 
@@ -351,7 +351,7 @@ task(
               path.join(
                 hre.config.paths.root,
                 "deployments",
-                `${hre.config.xdeploy.networks[i]}_deployment_debug.json`,
+                `${hre.config.xdeploy.contract}_${hre.config.xdeploy.networks[i]}_deployment_debug.json`,
               ),
             );
 


### PR DESCRIPTION
<!--
Thank you for using xdeployer and taking the time to send a pull request (PR)!

If you are introducing a new feature, please discuss it in an issue or in the discussions section before submitting your change.

Please:
 - consider the checklist items below
 - keep the ones that make sense for your PR, and
 - DELETE the items that DON'T make sense for your PR.
-->

#### PR Checklist

- [ ] Because this PR includes a **bug fix**, relevant tests have been included.
- [ ] Because this PR includes a **new feature**, the change was previously discussed in an [issue](https://github.com/pcaversaccio/xdeployer/issues) or in the [discussions](https://github.com/pcaversaccio/xdeployer/discussions) section.
- [x] I didn't do anything of this.

---

This PR simply suggests adding the contract name defined in the config file to the name of the deployment.json file which will help if the user is deploying multiple contracts, so each file will be `CONTRACTNAME_NETWORKNAME_deployment.json`.
