### PR TITLE
🔁 Upgrade Solidity Version to `0.8.24`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xdeployer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Hardhat plugin to deploy your smart contracts across multiple EVM chains with the same deterministic address.",
   "author": "Pascal Marco Caversaccio <pascal.caversaccio@hotmail.ch>",
   "license": "MIT",
@@ -45,7 +45,7 @@
     "@types/chai": "^4.3.11",
     "@types/fs-extra": "^11.0.4",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^20.11.15",
+    "@types/node": "^20.11.16",
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "chai": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ devDependencies:
     specifier: ^10.0.6
     version: 10.0.6
   "@types/node":
-    specifier: ^20.11.15
-    version: 20.11.15
+    specifier: ^20.11.16
+    version: 20.11.16
   "@typescript-eslint/eslint-plugin":
     specifier: ^6.20.0
     version: 6.20.0(@typescript-eslint/parser@6.20.0)(eslint@8.56.0)(typescript@5.3.3)
@@ -52,7 +52,7 @@ devDependencies:
     version: 1.3.1(prettier@3.2.4)
   ts-node:
     specifier: ^10.9.2
-    version: 10.9.2(@types/node@20.11.15)(typescript@5.3.3)
+    version: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
   typescript:
     specifier: ^5.3.3
     version: 5.3.3
@@ -1227,7 +1227,7 @@ packages:
         integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==,
       }
     dependencies:
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
     dev: true
 
   /@types/bn.js@5.1.5:
@@ -1236,7 +1236,7 @@ packages:
         integrity: sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==,
       }
     dependencies:
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
     dev: true
 
   /@types/chai@4.3.11:
@@ -1253,7 +1253,7 @@ packages:
       }
     dependencies:
       "@types/jsonfile": 6.1.4
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
     dev: true
 
   /@types/json-schema@7.0.15:
@@ -1269,7 +1269,7 @@ packages:
         integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==,
       }
     dependencies:
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
     dev: true
 
   /@types/lru-cache@5.1.1:
@@ -1293,10 +1293,10 @@ packages:
       }
     dev: true
 
-  /@types/node@20.11.15:
+  /@types/node@20.11.16:
     resolution:
       {
-        integrity: sha512-gscmuADZfvNULx1eyirVbr3kVOVZtpQtzKMCZpeSZcN6MfbkRXAR4s9/gsQ4CzxLHw6EStDtKLNtSDL3vbq05A==,
+        integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==,
       }
     dependencies:
       undici-types: 5.26.5
@@ -1308,7 +1308,7 @@ packages:
         integrity: sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==,
       }
     dependencies:
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
     dev: true
 
   /@types/readable-stream@2.3.15:
@@ -1317,7 +1317,7 @@ packages:
         integrity: sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==,
       }
     dependencies:
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
       safe-buffer: 5.1.2
     dev: true
 
@@ -1327,7 +1327,7 @@ packages:
         integrity: sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==,
       }
     dependencies:
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
     dev: true
 
   /@types/semver@7.5.6:
@@ -2949,7 +2949,7 @@ packages:
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.2(@types/node@20.11.15)(typescript@5.3.3)
+      ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
       tsort: 0.0.1
       typescript: 5.3.3
       undici: 5.28.2
@@ -4359,7 +4359,7 @@ packages:
       typescript: 5.3.3
     dev: true
 
-  /ts-node@10.9.2(@types/node@20.11.15)(typescript@5.3.3):
+  /ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3):
     resolution:
       {
         integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==,
@@ -4381,7 +4381,7 @@ packages:
       "@tsconfig/node12": 1.0.11
       "@tsconfig/node14": 1.0.3
       "@tsconfig/node16": 1.0.4
-      "@types/node": 20.11.15
+      "@types/node": 20.11.16
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3

--- a/src/contracts/CreateX.sol
+++ b/src/contracts/CreateX.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 /**
  * @title CreateX Factory Smart Contract

--- a/test/fixture-projects/hardhat-project-with-constructor/contracts/CreateX.sol
+++ b/test/fixture-projects/hardhat-project-with-constructor/contracts/CreateX.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 /**
  * @title CreateX Factory Smart Contract

--- a/test/fixture-projects/hardhat-project-with-constructor/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-with-constructor/hardhat.config.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.23",
+    version: "0.8.24",
     settings: {
       optimizer: {
         enabled: true,

--- a/test/fixture-projects/hardhat-project-without-constructor/contracts/CreateX.sol
+++ b/test/fixture-projects/hardhat-project-without-constructor/contracts/CreateX.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity ^0.8.23;
 
 /**
  * @title CreateX Factory Smart Contract

--- a/test/fixture-projects/hardhat-project-without-constructor/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-without-constructor/hardhat.config.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.23",
+    version: "0.8.24",
     settings: {
       optimizer: {
         enabled: true,

--- a/test/fixture-projects/sepolia-holesky-project-with-constructor/hardhat.config.ts
+++ b/test/fixture-projects/sepolia-holesky-project-with-constructor/hardhat.config.ts
@@ -5,7 +5,7 @@ import { ethers } from "ethers";
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.8.23",
+    version: "0.8.24",
     settings: {
       optimizer: {
         enabled: true,


### PR DESCRIPTION
### 🕓 Changelog

This PR bumps the Solidity version to [`0.8.24`](https://github.com/ethereum/solidity/releases/tag/v0.8.24) and adds the caret `^` to the `pragma` statement of `CreateX` to allow for `>0.8.23`-based, local deployment testing.

#### 🐶 Cute Animal Picture

![image](https://github.com/pcaversaccio/xdeployer/assets/25297591/f341fd29-b3f3-4fd7-adde-a6faa0bcd78d)